### PR TITLE
Remove unused mlflow dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,6 @@ dependencies:
   - pip
   - pip:
       - git+https://github.com/microsoft/protein-sequence-models.git
-      - mlflow
       - scikit-learn
       - seaborn
       - blosum

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setuptools.setup(
         "lmdb",
         "numpy",
         "sequence-models",
-        "mlflow",
         "scikit-learn",
         "blosum",
         "seaborn",


### PR DESCRIPTION
This PR removes an apparently vestigial installation of the `mlflow` library, which is no longer used anywhere in this codebase. 

As it is a fairly large dependency and currently has several [open known security issues](https://github.com/mlflow/mlflow/security), removing it as a dependency will simplify downstream use of `evodiff` models.